### PR TITLE
添加 Dockerfile 以支持容器化部署

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ LABEL authors="infinitycat233"
 
 WORKDIR /adapters
 
-COPY maim_message /appdata/maim_message
-RUN pip install -e /appdata/maim_message -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets] -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+COPY maim_message /maim_message
+RUN pip install -e /maim_message
+RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets]
 
 COPY test .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM nonebot/nb-cli:latest
+LABEL authors="infinitycat233"
+
+WORKDIR /adapters
+
+COPY maim_message /appdata/maim_message
+RUN pip install -e /appdata/maim_message -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets] -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+
+COPY test .
+
+EXPOSE 18002
+
+ENTRYPOINT ["nb", "run", "--reload"]


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加 Dockerfile 以支持应用程序的容器化部署

构建：
- 使用清华大学镜像配置项目依赖和 NoneBot 适配器的 pip 安装

```
- -i https://pypi.tuna.tsinghua.edu.cn/simple
```

部署：
- 创建一个 Dockerfile，使用 `nonebot/nb-cli` 基础镜像设置应用程序环境

杂项：
- 设置容器以暴露端口 18002，并使用 NoneBot CLI 作为入口点

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Dockerfile to support containerized deployment of the application

Build:
- Configure pip installations for project dependencies and NoneBot adapters using Tsinghua University mirror

Deployment:
- Create a Dockerfile that sets up the application environment using nonebot/nb-cli base image

Chores:
- Set up container to expose port 18002 and use NoneBot CLI as the entrypoint

</details>