### PR TITLE
添加workflow自动构建docker镜像

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Clone maim_message
+      run: git clone https://github.com/MaiM-with-u/maim_message maim_message
+
+    - name: Determine Image Tags
+      id: tags
+      run: |
+        echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot-adapter:latest,${{ secrets.DOCKERHUB_USERNAME }}/maimbot-adapter:latest" >> $GITHUB_OUTPUT
+
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.tags.outputs.tags }}
+        push: true
+        cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/maimbot-adapter:buildcache
+        cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/maimbot-adapter:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nonebot/nb-cli:latest
+FROM infinitycat/adapter-bottom:latest
 LABEL authors="infinitycat233"
 
 WORKDIR /adapters
@@ -7,7 +7,7 @@ COPY maim_message /maim_message
 RUN pip install -e /maim_message
 RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets]
 
-COPY . .
+COPY nonebot_plugin_maibot_adapters /adapters/src/plugins/nonebot_plugin_maibot_adapters
 
 EXPOSE 18002
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets]
 
 COPY nonebot_plugin_maibot_adapters /adapters/src/plugins/nonebot_plugin_maibot_adapters
 
-VOLUME /adapters/src/plugins
+VOLUME ["/adapters/src/plugins"]
 
 EXPOSE 18002
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets]
 
 COPY nonebot_plugin_maibot_adapters /adapters/src/plugins/nonebot_plugin_maibot_adapters
 
+VOLUME /adapters/src/plugins
+
 EXPOSE 18002
 
 ENTRYPOINT ["nb", "run", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,15 @@ COPY maim_message /maim_message
 RUN pip install -e /maim_message
 RUN pip install nonebot-adapter-onebot nonebot2[fastapi] nonebot2[websockets]
 
+COPY entrypoint.sh /entrypoint.sh
+COPY nonebot_plugin_maibot_adapters /backup/nonebot_plugin_maibot_adapters
 COPY nonebot_plugin_maibot_adapters /adapters/src/plugins/nonebot_plugin_maibot_adapters
 
 VOLUME ["/adapters/src/plugins"]
 
 EXPOSE 18002
 
-ENTRYPOINT ["nb", "run", "--reload"]
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["nb", "run", "--reload"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e  # 遇到错误立即退出
+
+# 目标目录
+TARGET_DIR="/adapters/src/plugins"
+
+# 如果目标目录为空，则从备份目录复制初始内容
+if [ -z "$(ls -A $TARGET_DIR)" ]; then
+  echo "检测到空目录，正在初始化 $TARGET_DIR..."
+  cp -r /backup/nonebot_plugin_maibot_adapters $TARGET_DIR/
+  echo "初始化完成"
+fi
+
+# 执行 Dockerfile 中的 CMD 或 docker run 传入的命令
+exec "$@"


### PR DESCRIPTION
需要添加一个的dockerhub用户信息登录以进行push

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加 GitHub Actions 工作流程，以自动构建和推送项目的 Docker 镜像

CI（持续集成）：
- 创建一个 GitHub Actions 工作流程，以便在推送到 master 分支以及向 master 分支发起 pull request 时，构建 Docker 镜像并将其推送到 DockerHub

部署：
- 配置用于 amd64 和 arm64 架构的多平台 Docker 镜像构建
- 使用 GitHub secrets 设置 Docker Hub 身份验证

杂项：
- 更新 Dockerfile 以使用不同的基础镜像
- 修改 Docker 镜像构建过程以复制特定的项目目录

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add GitHub Actions workflow to automatically build and push Docker image for the project

CI:
- Create a GitHub Actions workflow to build and push Docker image to DockerHub on push and pull requests to the master branch

Deployment:
- Configure multi-platform Docker image build for amd64 and arm64 architectures
- Set up Docker Hub authentication using GitHub secrets

Chores:
- Update Dockerfile to use a different base image
- Modify Docker image build process to copy specific project directory

</details>