### PR TITLE
从.env中读取fastapi配置

### DIFF
--- a/nonebot_plugin_maibot_adapters/bot.py
+++ b/nonebot_plugin_maibot_adapters/bot.py
@@ -1,4 +1,4 @@
-from nonebot import logger
+from nonebot import logger, get_plugin_config
 from nonebot.adapters.onebot.v11 import (
     Bot,
     MessageEvent,
@@ -20,7 +20,7 @@ import asyncio
 
 
 
-config = Config()
+config = get_plugin_config(Config)
 
 # 定义日志配置
 
@@ -28,7 +28,7 @@ class ChatBot:
     def __init__(self):
         self.bot = None  # bot 实例引用
         self._started = False
-        self.fastapi_url =  config.Fastapi_url
+        self.fastapi_url =  config.fastapi_url
         self.client = httpx.AsyncClient(timeout=60)  # 创建异步HTTP客户端
 
     async def _ensure_started(self):

--- a/nonebot_plugin_maibot_adapters/config.py
+++ b/nonebot_plugin_maibot_adapters/config.py
@@ -3,6 +3,6 @@ from pydantic import BaseModel
 
 class Config(BaseModel):
     """Plugin Config Here"""
-    Fastapi_url : str = "http://localhost:8000/api/message"  # 你的FastAPI地址 / 与maimcore的服务器（端口）相同
+    fastapi_url : str = "http://localhost:8000/api/message"  # 你的FastAPI地址 / 与maimcore的服务器（端口）相同
     platfrom :str = "nonebot-qq"    #如果你不知道这是什么那你就不要动它
     allow_group_list :list[str]  = []     #留空则为不启动QQ端白名单


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新配置加载机制以使用 NoneBot 的插件配置系统

增强：
- 修改配置加载方式，使用 `get_plugin_config()` 来获取插件设置

杂项：
- 将配置变量名从 'Fastapi_url' 重命名为 'fastapi_url'，以遵循 Python 命名规范

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update configuration loading mechanism to use NoneBot's plugin config system

Enhancements:
- Modify configuration loading to use get_plugin_config() for retrieving plugin settings

Chores:
- Rename configuration variable from 'Fastapi_url' to 'fastapi_url' to follow Python naming conventions

</details>