### PR TITLE
修复所有图片都被匹配为emoji的问题，因为subtype类型是字符串

### DIFF
--- a/nonebot_plugin_maibot_adapters/bot.py
+++ b/nonebot_plugin_maibot_adapters/bot.py
@@ -245,6 +245,7 @@ class ChatBot:
                     image_data = await asyncio.wait_for(bot.get_image(file=image_file),timeout=2)#2s不响应自动切换一个解决方式
                     file_path = image_data["file"]
                     base64_str = local_file_to_base64(file_path)
+                    subtype = str(subtype) # 确保类型一致性
                     if subtype == "0": #图片
                         image_type = 'image'
                     else:

--- a/nonebot_plugin_maibot_adapters/bot.py
+++ b/nonebot_plugin_maibot_adapters/bot.py
@@ -245,7 +245,7 @@ class ChatBot:
                     image_data = await asyncio.wait_for(bot.get_image(file=image_file),timeout=2)#2s不响应自动切换一个解决方式
                     file_path = image_data["file"]
                     base64_str = local_file_to_base64(file_path)
-                    if subtype == 0: #图片
+                    if subtype == "0": #图片
                         image_type = 'image'
                     else:
                         image_type = 'emoji'


### PR DESCRIPTION
如题，我是被麦麦突然发了一张我控制台截图吓到了，一路溯源到了这里。
![image](https://github.com/user-attachments/assets/fad365df-fcb4-4459-b79e-253164488fdc)

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复：
- 修正了在检查子类型时对图像类型的检测，将整数 0 的比较更改为字符串 '0'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct image type detection when checking the subtype by changing the comparison from integer 0 to string '0'

</details>