### PR TITLE
修改download_image_url函数解决SSL握手失败问题

### DIFF
--- a/nonebot_plugin_maibot_adapters/util.py
+++ b/nonebot_plugin_maibot_adapters/util.py
@@ -94,24 +94,44 @@ async def download_image_url(url: str) -> str:
     try:
         import ssl
         from aiohttp import ClientSession, ClientTimeout, TCPConnector
-        from yarl import URL  # 使用yarl解析URL
+        from yarl import URL
 
         # 使用yarl解析URL获取主机名
-        parsed_url = URL(url)
-        hostname = parsed_url.host  # 直接获取主机名
+        try:
+            parsed_url = URL(url)
+            hostname = parsed_url.host
+        except Exception as e:
+            logger.error(f"URL解析失败: {url} - {str(e)}")
+            raise ValueError(f"无效的URL格式: {url}")
+
+        # 确保成功提取主机名
+        if not hostname:
+            logger.error(f"无法从URL中提取主机名: {url}")
+            raise ValueError("URL中缺少有效的主机名")
 
         # 创建自定义SSL上下文
         ssl_context = ssl.create_default_context()
+        
+        # 禁用不安全协议
         ssl_context.options |= (
-            ssl.OP_NO_SSLv3 |  # 禁用SSLv3
-            ssl.OP_NO_TLSv1 |  # 禁用TLSv1.0
-            ssl.OP_NO_TLSv1_1  # 禁用TLSv1.1
+            ssl.OP_NO_SSLv3 |
+            ssl.OP_NO_TLSv1 |
+            ssl.OP_NO_TLSv1_1
         )
-        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2  # 强制TLSv1.2+
-        ssl_context.set_ciphers('DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES')  # 更兼容的加密套件
+        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2  # 强制使用TLSv1.2+
 
-        # 显式设置SNI（关键步骤）
-        ssl_context.server_hostname = hostname  # 设置SNI主机名
+        # 配置加密套件：
+        # - DEFAULT: 使用OpenSSL默认的安全套件
+        # - !aNULL: 禁用无身份验证的套件（易受中间人攻击）
+        # - !eNULL: 禁用无加密的套件
+        # - !MD5: 禁用使用MD5哈希的套件（已不安全）
+        # - !3DES: 禁用三重DES（性能差且存在SWEET32攻击风险）
+        # - !DES: 禁用DES（密钥长度过短）
+        ssl_context.set_ciphers('DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES')
+
+        # 显式设置SNI
+        # 避免某些服务器因缺少SNI信息而拒绝连接
+        ssl_context.server_hostname = hostname
 
         # 创建带自定义SSL上下文的连接器
         connector = TCPConnector(ssl=ssl_context)


### PR DESCRIPTION
问题：
在从multimedia.nt.qq.com.cn下载图片时，怀疑缺少SNI配置和安全密码套件，导致SSL握手失败（SSLV3_ALERT_HANDSHAKE_FAILURE）

主要变化：
更新SSL上下文配置，禁用不安全协议（SSLv3、TLSv1.0、TLSv1.1）。
强制使用TLSv1.2+和安全密码套件。
明确设置服务器名称指示（SNI）以进行证书验证。
添加了yarl作为依赖项，以实现稳健的URL处理。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进图片下载的 SSL 配置，以解决 SSL 握手失败问题并增强安全性

新特性：
- 添加 yarl 库以实现强大的 URL 解析

Bug 修复：
- 通过实施强大的 SSL 上下文配置，解决从 multimedia.nt.qq.com.cn 下载图片时发生的 SSL 握手失败问题

增强功能：
- 通过禁用过时的协议和配置安全的密码套件来升级 SSL 安全性
- 实施显式服务器名称指示 (SNI) 以进行证书验证
- 改进图片下载期间的 URL 解析和错误处理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve SSL configuration for image downloading to resolve SSL handshake failures and enhance security

New Features:
- Add yarl library for robust URL parsing

Bug Fixes:
- Resolve SSL handshake failures when downloading images from multimedia.nt.qq.com.cn by implementing robust SSL context configuration

Enhancements:
- Upgrade SSL security by disabling outdated protocols and configuring secure cipher suites
- Implement explicit Server Name Indication (SNI) for certificate validation
- Improve URL parsing and error handling during image downloads

</details>