### PR TITLE
引用消息中增加引用内容

### DIFF
--- a/nonebot_plugin_maibot_adapters/bot.py
+++ b/nonebot_plugin_maibot_adapters/bot.py
@@ -320,7 +320,7 @@ class ChatBot:
                                    group_name=(await bot.get_group_info(group_id = event.group_id,no_cache=True))["group_name"], 
                                    platform=config.platfrom)
 
-        message_content =  f"回复{event.reply.sender.nickname}({event.reply.sender.user_id})的消息，说："
+        message_content =  f"[回复 {event.reply.sender.nickname}({event.reply.sender.user_id})：{event.reply.message}]，说："
         # message_content += f"-{event.reply.sender.nickname}(id{event.reply.user_id}):{event.reply.message}\n回复了以下信息："
         message_content+=event.get_plaintext()
         # logger.info(f"\n\n\n{message_content}\n\n\n")


### PR DESCRIPTION
[对他人的引用回复无法识别上下文](https://github.com/MaiM-with-u/MaiBot/issues/728)
增加引用内容，让bot能够看到欲回复发言的引用内容。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强回复消息处理，在上下文中包含原始消息内容

Bug 修复：
- 改进对回复消息的上下文识别，添加原始消息内容

增强功能：
- 修改回复消息处理方式，包含被回复的原始消息的完整文本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance reply message handling by including the original message content in the context

Bug Fixes:
- Improve context recognition for replied messages by adding the original message content

Enhancements:
- Modify reply message processing to include the full text of the original message being replied to

</details>