### PR TITLE
发送更详细的引用消息内容

### DIFF
--- a/nonebot_plugin_maibot_adapters/__init__.py
+++ b/nonebot_plugin_maibot_adapters/__init__.py
@@ -33,10 +33,10 @@ async def _(bot: Bot, event: MessageEvent):
     # 处理合并转发消息
     if "forward" in event.message:
         await chat_bot.handle_forward_message(event, bot)
-    elif any(segment.type in {"image", "emoji"} for segment in event.message):  
-        await chat_bot.handle_image_message(event, bot)
     elif event.reply:
         await chat_bot.handle_reply_message(event,bot)
+    elif any(segment.type in {"image", "emoji"} for segment in event.message):  
+        await chat_bot.handle_image_message(event, bot)
     else:
         await chat_bot.handle_message(event, bot)
 

--- a/nonebot_plugin_maibot_adapters/bot.py
+++ b/nonebot_plugin_maibot_adapters/bot.py
@@ -82,7 +82,7 @@ class ChatBot:
             #这里是at信息的处理逻辑 可能会比较混乱，但是暂时没找到更好的解决方式
             msg = str(event.raw_message)
             logger.info(f"{msg}")
-            qq_ids = list(set(re.findall(r'\[CQ:at,qq=(\d+),name=[\s\S]*?\]', msg))) 
+            qq_ids = list(set(re.findall(r'\[CQ:at,qq=(\d+)\]', msg))) 
             if not qq_ids:  # 没有 @ 消息
                 message_content = msg
             else:
@@ -97,7 +97,7 @@ class ChatBot:
 
                 # 替换 @ 消息，避免 KeyError
                 message_content = re.sub(
-                    r'\[CQ:at,qq=(\d+),name=[\s\S]*?\]',
+                    r'\[CQ:at,qq=(\d+)\]',
                     lambda m: f'@{nicknames.get(m.group(1), f"用户{m.group(1)}")}（id:{m.group(1)}）',
                     msg
                 )


### PR DESCRIPTION
[对他人的引用回复无法识别上下文](https://github.com/MaiM-with-u/MaiBot/issues/728)
 #19 
增加引用内容，让bot能够看到欲回复发言的引用内容。

好的，这是对pull request摘要的中文翻译：

## Sourcery 总结

增强消息处理，以改进对回复消息的上下文识别，特别是对于带有引用和多种消息类型的消息。

Bug修复：
- 改进了对回复消息的上下文识别，通过提取和保留原始消息的内容和发送者信息。

增强功能：
- 将消息段处理重构为一个可重用函数，以一致地处理不同的消息类型。
- 修改回复消息处理，以包含有关原始消息的更详细的上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance message handling to improve context recognition for replied messages, particularly for messages with references and multiple message types

Bug Fixes:
- Improve context recognition for replied messages by extracting and preserving the original message's content and sender information

Enhancements:
- Refactor message segment handling into a reusable function to process different message types consistently
- Modify reply message processing to include more detailed context about the original message

</details>